### PR TITLE
[fix] Add in new UID lengths

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -492,7 +492,9 @@
 
       function generatePreview() {
         const userId = userIdInput.value.trim();
-        if (!userId || isNaN(userId) || !(userId.length == 18 || userId.length == 17)) {
+        // Allow 17, 18, or 19 digit numbers
+        if (!/^\d{17,19}$/.test(userId)) {
+          alert('Please enter a valid Discord User ID (17-19 digits).');
           return;
         }
 

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -492,9 +492,9 @@
 
       function generatePreview() {
         const userId = userIdInput.value.trim();
-        // Allow 17, 18, or 19 digit numbers
-        if (!/^\d{17,19}$/.test(userId)) {
-          alert('Please enter a valid Discord User ID (17-19 digits).');
+        // typically 17-19 digits. Since it's also checked on the backend, we can be less strict
+        if (!/^\d{17,}$/.test(userId)) {
+          alert('Please enter a valid Discord User ID.');
           return;
         }
 

--- a/src/helpers/discord.ts
+++ b/src/helpers/discord.ts
@@ -21,7 +21,8 @@ export interface UserProperties {
 }
 
 export const validateId = (id: string) => {
-  return id.match(/^[0-9]{17,19}$/);
+  // typically 17-19 digits. Invalid IDs won't work regardless, so this should only function as an early exit.
+  return id.match(/^[0-9]{17,}$/);
 }
 
 export function roundImageSize(size: number): 64 | 128 | 256 | 512 | 1024 {


### PR DESCRIPTION
Discord recently started assigning people 19 digit UIDs, this allow support for this allowing between 17 and 19

This closes #4 properly, as I managed to root the issues down.

✅ I have tested this code, and can verify it runs as intended
✅ I have left a comment where I have changed the code so you can modify it in the future if needed.