### PR TITLE
security: harden URItoBase64 image fetch against SSRF and resource abuse

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -8,28 +8,128 @@ const mimeTypeMap: { [key: string]: string } = {
   gif: "image/gif",
 };
 
-const cache = new LRUCache<string, string>(1000)
+// Trusted domains from which arbitrary image URLs are allowed.
+// All other hostnames are rejected to prevent SSRF / open-proxy abuse.
+const ALLOWED_HOSTNAMES = new Set([
+  // Discord CDN
+  "cdn.discordapp.com",
+  "media.discordapp.net",
+  // GitHub
+  "avatars.githubusercontent.com",
+  "raw.githubusercontent.com",
+  "user-images.githubusercontent.com",
+  "github.com",
+  // Imgur
+  "i.imgur.com",
+  "imgur.com",
+  // Twitch
+  "static-cdn.jtvnw.net",
+  // Steam
+  "cdn.cloudflare.steamstatic.com",
+  "steamcdn-a.akamaihd.net",
+  // Generic image CDNs used by rich-presence apps
+  "i.scdn.co",           // Spotify album art
+  "lh3.googleusercontent.com", // Google user content
+]);
+
+const FETCH_TIMEOUT_MS = 5_000;
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024; // 5 MB
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface CacheEntry {
+  data: string;
+  expiresAt: number;
+}
+
+const cache = new LRUCache<string, CacheEntry>(1000);
 
 /**
  * Converts a URI to a Base64 string.
  * If the URI is a local file, it will be read using `fs.readFile`, otherwise it will be fetched.
+ *
+ * Security hardening applied to remote URLs:
+ * - Domain whitelist: only fetches from trusted hostnames to prevent SSRF.
+ * - 5-second fetch timeout via AbortController.
+ * - Rejects responses larger than 5 MB (Content-Length header + streaming byte-count).
+ * - 1-hour TTL on the LRU cache so avatar/asset changes are reflected within an hour.
+ *
  * @param uri The URI to convert.
  */
 export async function URItoBase64(uri: string) {
   if (!uri) { return null }
+
   const cached = cache.get(uri);
-  if (cached) return cached;
+  if (cached && Date.now() < cached.expiresAt) return cached.data;
+
   const ext = uri.split('.').pop();
   if (uri.startsWith('./')) {
     const buffer = await fs.readFile(uri);
     const dataType = mimeTypeMap[ext as string] || "application/octet-stream";
     return `data:${dataType};base64,${buffer.toString('base64')}`;
   }
-  const res = await fetch(uri);
-  const buffer = await res.arrayBuffer();
+
+  // --- Domain whitelist check ---
+  let hostname: string;
+  try {
+    hostname = new URL(uri).hostname;
+  } catch {
+    throw new Error(`URItoBase64: invalid URL: ${uri}`);
+  }
+  if (!ALLOWED_HOSTNAMES.has(hostname)) {
+    throw new Error(`URItoBase64: hostname not allowed: ${hostname}`);
+  }
+
+  // --- Fetch with timeout ---
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  let res: Response;
+  try {
+    res = await fetch(uri, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!res.ok) {
+    throw new Error(`URItoBase64: fetch failed with status ${res.status} for ${uri}`);
+  }
+
+  // --- Content-Length pre-check ---
+  const contentLengthHeader = res.headers.get("content-length");
+  if (contentLengthHeader !== null) {
+    const contentLength = parseInt(contentLengthHeader, 10);
+    if (!isNaN(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+      // Discard the body to avoid keeping the connection open.
+      await res.body?.cancel();
+      throw new Error(`URItoBase64: response too large (${contentLength} bytes) for ${uri}`);
+    }
+  }
+
+  // --- Stream with byte-count guard ---
+  const reader = res.body?.getReader();
+  if (!reader) {
+    throw new Error(`URItoBase64: response body is not readable for ${uri}`);
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new Error(`URItoBase64: response exceeded ${MAX_RESPONSE_BYTES} bytes for ${uri}`);
+    }
+    chunks.push(value);
+  }
+
+  const buffer = Buffer.concat(chunks.map(c => Buffer.from(c)));
   const contentType = res.headers.get("content-type");
-  const output = `data:${contentType};base64,${Buffer.from(buffer).toString("base64")}`;
-  cache.set(uri, output);
+  const output = `data:${contentType};base64,${buffer.toString("base64")}`;
+
+  cache.set(uri, { data: output, expiresAt: Date.now() + CACHE_TTL_MS });
   return output;
 }
 


### PR DESCRIPTION
## Summary

This PR hardens `URItoBase64()` in `src/helpers/utils.ts` to prevent the bot from being used as an SSRF vector or an open download proxy, and to ensure avatar/asset changes are reflected in a reasonable time window.

## Changes

### 1. Domain whitelist (SSRF prevention)
Before making any outbound fetch, the URL's hostname is validated against an explicit allowlist of trusted image-hosting domains:

| Domain | Purpose |
|---|---|
| `cdn.discordapp.com`, `media.discordapp.net` | Discord CDN (avatars, banners, decorations, app icons) |
| `avatars.githubusercontent.com`, `raw.githubusercontent.com`, `user-images.githubusercontent.com`, `github.com` | GitHub user content |
| `i.imgur.com`, `imgur.com` | Imgur |
| `static-cdn.jtvnw.net` | Twitch (rich presence art) |
| `cdn.cloudflare.steamstatic.com`, `steamcdn-a.akamaihd.net` | Steam (game art) |
| `i.scdn.co` | Spotify album art |
| `lh3.googleusercontent.com` | Google user content |

Any URL with a hostname not in this set throws immediately, preventing an attacker from supplying an arbitrary URL (e.g. an internal AWS metadata endpoint) and having the server fetch it.

### 2. AbortController with 5-second timeout
`fetch()` is now wrapped with an `AbortController` that fires after **5 000 ms**. The timeout is always cleared via `finally` to prevent timer leaks. This stops slow-loris-style attacks and hung connections from blocking the rendering pipeline.

### 3. >5 MB response rejection
Two layers of protection:
- **Content-Length pre-check**: if the response advertises a body larger than 5 MB, the body is immediately cancelled and an error is thrown before a single byte is buffered.
- **Streaming byte-count guard**: the response body is consumed chunk-by-chunk via `ReadableStream`. A running total is kept; if it exceeds 5 MB mid-stream the reader is cancelled and an error is thrown. This handles servers that omit `Content-Length` or lie about it.

### 4. 1-hour TTL on the LRU cache
`mnemonist`'s `LRUCache` has no native TTL support, so each entry now stores `{ data, expiresAt }`. On cache hit the expiry is checked; stale entries are re-fetched transparently. This ensures avatar changes, banner updates, and decoration swaps are reflected within **one hour** rather than persisting indefinitely for the life of the process.

## Security impact

| Threat | Before | After |
|---|---|---|
| SSRF via attacker-controlled URL | Unmitigated | Blocked by hostname whitelist |
| Bot used as open download proxy | Unmitigated | Blocked by hostname whitelist |
| Memory exhaustion via huge image | Unmitigated | Blocked at 5 MB (header + stream) |
| Hung connection / slow-loris | Unmitigated | Aborted after 5 s |
| Stale avatars cached forever | Yes | Expired after 1 h |

## Testing

`tsc --noEmit` passes with no errors. The changes are confined to `URItoBase64` and are backwards-compatible for all current callers — local `./`-prefixed paths bypass all network checks as before.