### PR TITLE
feat: add named theme presets (Catppuccin, Dracula, Nord, Tokyo Night, GitHub Dark, Gruvbox, Solarized)

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -94,7 +94,17 @@
         { value: 'light', label: 'Light' },
         { value: 'nitroDark', label: 'Nitro Dark' },
         { value: 'nitroLight', label: 'Nitro Light' },
-        { value: 'custom', label: 'Custom' }
+        { value: 'custom', label: 'Custom' },
+        // Named presets
+        { value: 'catppuccinMocha', label: 'Catppuccin Mocha' },
+        { value: 'catppuccinLatte', label: 'Catppuccin Latte' },
+        { value: 'catppuccinFrappe', label: 'Catppuccin Frappé' },
+        { value: 'dracula', label: 'Dracula' },
+        { value: 'nord', label: 'Nord' },
+        { value: 'tokyoNight', label: 'Tokyo Night' },
+        { value: 'githubDark', label: 'GitHub Dark' },
+        { value: 'gruvbox', label: 'Gruvbox' },
+        { value: 'solarized', label: 'Solarized' },
       ];
 
       const showNitro = theme === 'nitroDark' || theme === 'nitroLight';

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -95,7 +95,8 @@
         { value: 'nitroDark', label: 'Nitro Dark' },
         { value: 'nitroLight', label: 'Nitro Light' },
         { value: 'custom', label: 'Custom' },
-        // Named presets
+      ];
+      const namedThemes = [
         { value: 'catppuccinMocha', label: 'Catppuccin Mocha' },
         { value: 'catppuccinLatte', label: 'Catppuccin Latte' },
         { value: 'catppuccinFrappe', label: 'Catppuccin Frappé' },
@@ -105,7 +106,7 @@
         { value: 'githubDark', label: 'GitHub Dark' },
         { value: 'gruvbox', label: 'Gruvbox' },
         { value: 'solarized', label: 'Solarized' },
-      ];
+      ]
 
       const showNitro = theme === 'nitroDark' || theme === 'nitroLight';
       const showCustom = theme === 'custom';
@@ -115,6 +116,20 @@
           <span class="label">Theme</span>
           <div style="margin-bottom: 15px;">
             ${themes.map(t => html`
+              <div class="checkbox-container" key=${t.value}>
+                <input
+                  type="radio"
+                  id=${t.value + 'Theme'}
+                  name="themeType"
+                  value=${t.value}
+                  checked=${theme === t.value}
+                  onChange=${() => setTheme(t.value)}
+                />
+                <label for=${t.value + 'Theme'}>${t.label}</label>
+              </div>
+            `)}
+            <hr style="margin: 15px 0;" />
+            ${namedThemes.map(t => html`
               <div class="checkbox-container" key=${t.value}>
                 <input
                   type="radio"
@@ -181,6 +196,8 @@
       }
       if (state.overrideBanner && state.bannerUrl) {
         params.append('banner', state.bannerUrl);
+      } else if (state.overrideBanner && state.bannerColor) {
+        params.append('bannerColor', state.bannerColor.replace(/^#/, ''));
       }
       if (!state.enableDecoration) {
         params.append('hideDecoration', 'true');
@@ -231,6 +248,7 @@
       const [width, setWidth] = useState('512');
       const [overrideBanner, setOverrideBanner] = useState(false);
       const [bannerUrl, setBannerUrl] = useState('');
+      const [bannerColor, setBannerColor] = useState('#000000');
 
       // UI state
       const [copySuccess, setCopySuccess] = useState(false);
@@ -267,7 +285,8 @@
           customColors,
           width,
           overrideBanner,
-          bannerUrl
+          bannerUrl,
+          bannerColor
         };
 
         const url = buildPreviewUrl(state);
@@ -301,7 +320,7 @@
           if (!silent) alert('Failed to generate preview. Please check the User ID and try again.');
           setPreviewOpacity(1);
         }
-      }, [userId, enableAboutMe, aboutMe, enableDecoration, enableSpotify, theme, nitroColors, customColors, width, overrideBanner, bannerUrl]);
+      }, [userId, enableAboutMe, aboutMe, enableDecoration, enableSpotify, theme, nitroColors, customColors, width, overrideBanner, bannerUrl, bannerColor]);
 
       // Copy URL handler
       const copyUrl = useCallback(async () => {
@@ -463,6 +482,11 @@
                     onInput=${(e) => setBannerUrl(e.target.value)}
                     placeholder="https://example.com/banner.png"
                     disabled=${!overrideBanner}
+                  />
+                  <span class="label">Banner Color</span>
+                  <${ColorInput}
+                    value=${bannerColor}
+                    onChange=${setBannerColor}
                   />
                 `}
               </div>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,10 +1,10 @@
 import readyClient from "../bot";
 import { makeCard } from "../helpers/card";
-import { CardOptions } from "../types";
 import { validateId, fetchUserInfo } from "../helpers/discord";
 import type { RequestHandler } from "express";
 import { URItoBase64 } from "../helpers/utils";
-import * as z from "zod/v4";
+import { ParamsSchema } from "../schema";
+import type { CardOptions } from "../schema";
 import { discordMemberToLanyard } from "../helpers/lanyard";
 
 export const discordSelf: RequestHandler = async (req, res, next) => {
@@ -44,55 +44,6 @@ export const discordDebug: RequestHandler = async (req, res, next) => {
     next(error);
   }
 }
-
-const isHex = (input: string) => !isNaN(parseInt(input, 16)) && input.length >= 3 && input.length <= 8
-const hexMessage = { error: "Colors must be in hexadecimal format without a leading #" }
-
-const ParamsSchema = z.object({
-  width: z.coerce.number().default(500),
-  animate: z.coerce.boolean().default(false),
-  banner: z.url({
-    protocol: /^https?$/,
-    hostname: z.regexes.domain,
-    error: "Banner URL must be a valid HTTP or HTTPS URL."
-  }).optional(),
-  aboutMe: z.string().optional(),
-  hideDecoration: z.coerce.boolean().default(false),
-  hideSpotify: z.coerce.boolean().default(false),
-  theme: z.enum([
-    "dark", "light", "custom", "nitroDark", "nitroLight",
-    // Named presets
-    "catppuccinMocha", "catppuccinLatte", "catppuccinFrappe",
-    "dracula", "nord", "tokyoNight", "githubDark", "gruvbox", "solarized",
-  ]).default("dark"),
-  primaryColor: z.string().default("ecaff3").refine(isHex, hexMessage).transform((val) => "#" + val),
-  accentColor: z.string().default("44a17a").refine(isHex, hexMessage).transform((val) => "#" + val),
-  colorB1: z.string().default("111214").refine(isHex, hexMessage).transform((val) => "#" + val),
-  colorB2: z.string().default("313338").refine(isHex, hexMessage).transform((val) => "#" + val),
-  colorB3: z.string().default("505059").refine(isHex, hexMessage).transform((val) => "#" + val),
-  colorT1: z.string().default("fff").refine(isHex, hexMessage).transform((val) => "#" + val),
-  colorT2: z.string().default("d2d6d8").refine(isHex, hexMessage).transform((val) => "#" + val),
-}).check((ctx) => {
-  const data = ctx.value;
-  if (data.theme === "nitroDark" || data.theme === "nitroLight") {
-    if (!data.primaryColor || !data.accentColor) {
-      ctx.issues.push({
-        code: "custom",
-        error: "Primary and accent colors must be provided for nitro themes.",
-        input: ctx.value,
-      });
-    }
-  }
-  if (data.theme === "custom") {
-    if (!data.colorB1 || !data.colorB2 || !data.colorB3 || !data.colorT1 || !data.colorT2) {
-      ctx.issues.push({
-        code: "custom",
-        error: "Custom theme colors must be provided when theme is 'custom'.",
-        input: ctx.value
-      });
-    }
-  }
-});
 
 const errorSvg = (
   errorMessage: string

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -59,7 +59,12 @@ const ParamsSchema = z.object({
   aboutMe: z.string().optional(),
   hideDecoration: z.coerce.boolean().default(false),
   hideSpotify: z.coerce.boolean().default(false),
-  theme: z.enum(["dark", "light", "custom", "nitroDark", "nitroLight"]).default("dark"),
+  theme: z.enum([
+    "dark", "light", "custom", "nitroDark", "nitroLight",
+    // Named presets
+    "catppuccinMocha", "catppuccinLatte", "catppuccinFrappe",
+    "dracula", "nord", "tokyoNight", "githubDark", "gruvbox", "solarized",
+  ]).default("dark"),
   primaryColor: z.string().default("ecaff3").refine(isHex, hexMessage).transform((val) => "#" + val),
   accentColor: z.string().default("44a17a").refine(isHex, hexMessage).transform((val) => "#" + val),
   colorB1: z.string().default("111214").refine(isHex, hexMessage).transform((val) => "#" + val),

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -90,7 +90,7 @@ export const SVGCard: React.FC<SVGCardProps> = ({
 
       <UserCardBackground
         colors={colors}
-        nitro={useNitroTheme}
+        options={options}
         totalHeight={totalHeight}
         banner={banner}
         user={user}

--- a/src/components/UserCardBackground.tsx
+++ b/src/components/UserCardBackground.tsx
@@ -1,23 +1,28 @@
 import React from "react";
-import { ColorTheme } from "../types";
-import { bannerHeight } from "../helpers/card";
+import { CardOptions, ColorTheme } from "../types";
+import { bannerHeight, isNitroProfile } from "../helpers/card";
 import { UserProperties } from "../helpers/discord";
 
 interface Props {
   colors: ColorTheme;
-  nitro: boolean;
+  options: CardOptions;
   totalHeight: number;
   banner: string | null;
   user: UserProperties;
 }
 export default function cardBackground({
   colors,
-  nitro,
+  options,
   totalHeight,
   banner,
   user,
 }: Props) {
   const bgColor = colors.colorB1;
+  const nitro = isNitroProfile(options.theme);
+  const bannerFill = banner ? colors.colorB2 : 
+    options.bannerColor ? options.bannerColor :
+    user.accentColor || bgColor;
+  
   if (nitro) {
     return (
       <g>
@@ -86,7 +91,7 @@ export default function cardBackground({
                 width="700"
                 height={bannerHeight}
                 style={{
-                  fill: banner ? colors.colorB2 : user.accentColor || bgColor,
+                  fill: bannerFill,
                 }}
               />
               {banner && (

--- a/src/helpers/card.ts
+++ b/src/helpers/card.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { UserProperties } from "./discord";
 import { setOpacity } from "./utils";
-import { darkColors, lightColors } from "./themes";
+import { darkColors, lightColors, presetThemes } from "./themes";
 import { BakedDisplayableComponent, CardOptions, DisplayableComponent, PrerenderProps } from "../types";
 import { SVGCard } from "../components/UserCard";
 import { spotifyActivity } from "../displayables/SpotifyActivity";
@@ -48,6 +48,8 @@ export const makeCard = async (user: UserProperties, options: CardOptions) => {
       colorT1: options.colorT1,
       colorT2: options.colorT2,
     }
+  } else if (options.theme in presetThemes) {
+    colors = { ...presetThemes[options.theme] };
   }
   const useNitroTheme = isNitroProfile(options.theme);
   if (useNitroTheme) {

--- a/src/helpers/themes.ts
+++ b/src/helpers/themes.ts
@@ -1,5 +1,79 @@
 import { ColorTheme } from "../types";
 
+export const presetThemes: Record<string, ColorTheme> = {
+  // Catppuccin Mocha
+  catppuccinMocha: {
+    colorB1: "#1e1e2e",
+    colorB2: "#313244",
+    colorB3: "#45475a",
+    colorT1: "#cdd6f4",
+    colorT2: "#a6adc8",
+  },
+  // Catppuccin Latte
+  catppuccinLatte: {
+    colorB1: "#eff1f5",
+    colorB2: "#e6e9ef",
+    colorB3: "#ccd0da",
+    colorT1: "#4c4f69",
+    colorT2: "#5c5f77",
+  },
+  // Catppuccin Frappé
+  catppuccinFrappe: {
+    colorB1: "#303446",
+    colorB2: "#414559",
+    colorB3: "#51576d",
+    colorT1: "#c6d0f5",
+    colorT2: "#a5adce",
+  },
+  // Dracula
+  dracula: {
+    colorB1: "#282a36",
+    colorB2: "#383a59",
+    colorB3: "#44475a",
+    colorT1: "#f8f8f2",
+    colorT2: "#6272a4",
+  },
+  // Nord
+  nord: {
+    colorB1: "#2e3440",
+    colorB2: "#3b4252",
+    colorB3: "#434c5e",
+    colorT1: "#eceff4",
+    colorT2: "#d8dee9",
+  },
+  // Tokyo Night
+  tokyoNight: {
+    colorB1: "#1a1b26",
+    colorB2: "#24283b",
+    colorB3: "#414868",
+    colorT1: "#c0caf5",
+    colorT2: "#a9b1d6",
+  },
+  // GitHub Dark
+  githubDark: {
+    colorB1: "#0d1117",
+    colorB2: "#161b22",
+    colorB3: "#21262d",
+    colorT1: "#e6edf3",
+    colorT2: "#8b949e",
+  },
+  // Gruvbox
+  gruvbox: {
+    colorB1: "#282828",
+    colorB2: "#3c3836",
+    colorB3: "#504945",
+    colorT1: "#ebdbb2",
+    colorT2: "#d5c4a1",
+  },
+  // Solarized Dark
+  solarized: {
+    colorB1: "#002b36",
+    colorB2: "#073642",
+    colorB3: "#586e75",
+    colorT1: "#eee8d5",
+    colorT2: "#93a1a1",
+  },
+};
 
 export const darkColors: ColorTheme = {
   colorB1: "#111214",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,102 @@
+import * as z from "zod/v4";
+
+const isHex = (input: string) => !isNaN(parseInt(input, 16)) && input.length >= 3 && input.length <= 8;
+const hexMessage = { error: "Colors must be in hexadecimal format without a leading #" };
+
+export const ParamsSchema = z
+  .object({
+    width: z.coerce.number().default(500),
+    animate: z.coerce.boolean().default(false),
+    banner: z
+      .url({
+        protocol: /^https?$/,
+        hostname: z.regexes.domain,
+        error: "Banner URL must be a valid HTTP or HTTPS URL.",
+      })
+      .optional(),
+    bannerColor: z
+      .string()
+      .refine(isHex, hexMessage)
+      .transform((val) => "#" + val)
+      .optional(),
+    aboutMe: z.string().optional(),
+    hideDecoration: z.coerce.boolean().default(false),
+    hideSpotify: z.coerce.boolean().default(false),
+    theme: z
+      .enum([
+        "dark",
+        "light",
+        "custom",
+        "nitroDark",
+        "nitroLight",
+        // Named presets
+        "catppuccinMocha",
+        "catppuccinLatte",
+        "catppuccinFrappe",
+        "dracula",
+        "nord",
+        "tokyoNight",
+        "githubDark",
+        "gruvbox",
+        "solarized",
+      ])
+      .default("dark"),
+    primaryColor: z
+      .string()
+      .default("ecaff3")
+      .refine(isHex, hexMessage)
+      .transform((val) => "#" + val),
+    accentColor: z
+      .string()
+      .default("44a17a")
+      .refine(isHex, hexMessage)
+      .transform((val) => "#" + val),
+    colorB1: z
+      .string()
+      .default("111214")
+      .refine(isHex, hexMessage)
+      .transform((val) => "#" + val),
+    colorB2: z
+      .string()
+      .default("313338")
+      .refine(isHex, hexMessage)
+      .transform((val) => "#" + val),
+    colorB3: z
+      .string()
+      .default("505059")
+      .refine(isHex, hexMessage)
+      .transform((val) => "#" + val),
+    colorT1: z
+      .string()
+      .default("fff")
+      .refine(isHex, hexMessage)
+      .transform((val) => "#" + val),
+    colorT2: z
+      .string()
+      .default("d2d6d8")
+      .refine(isHex, hexMessage)
+      .transform((val) => "#" + val),
+  })
+  .check((ctx) => {
+    const data = ctx.value;
+    if (data.theme === "nitroDark" || data.theme === "nitroLight") {
+      if (!data.primaryColor || !data.accentColor) {
+        ctx.issues.push({
+          code: "custom",
+          error: "Primary and accent colors must be provided for nitro themes.",
+          input: ctx.value,
+        });
+      }
+    }
+    if (data.theme === "custom") {
+      if (!data.colorB1 || !data.colorB2 || !data.colorB3 || !data.colorT1 || !data.colorT2) {
+        ctx.issues.push({
+          code: "custom",
+          error: "Custom theme colors must be provided when theme is 'custom'.",
+          input: ctx.value,
+        });
+      }
+    }
+  });
+
+export type CardOptions = z.infer<typeof ParamsSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,9 @@ export interface CardOptions {
   aboutMe?: string;
   hideDecoration: boolean;
   hideSpotify: boolean;
-  theme: "dark" | "light" | "custom" | "nitroDark" | "nitroLight";
+  theme: "dark" | "light" | "custom" | "nitroDark" | "nitroLight"
+    | "catppuccinMocha" | "catppuccinLatte" | "catppuccinFrappe"
+    | "dracula" | "nord" | "tokyoNight" | "githubDark" | "gruvbox" | "solarized";
   primaryColor: string;
   accentColor: string;
   colorB1: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { Activity } from "discord.js";
 import React from "react";
 import { UserProperties } from "./helpers/discord";
+import type { CardOptions } from "./schema";
 
 export interface ColorTheme {
   colorB1: string;
@@ -10,24 +11,7 @@ export interface ColorTheme {
   colorT2: string;
 }
 
-export interface CardOptions {
-  width: number;
-  animate: boolean;
-  banner?: string;
-  aboutMe?: string;
-  hideDecoration: boolean;
-  hideSpotify: boolean;
-  theme: "dark" | "light" | "custom" | "nitroDark" | "nitroLight"
-    | "catppuccinMocha" | "catppuccinLatte" | "catppuccinFrappe"
-    | "dracula" | "nord" | "tokyoNight" | "githubDark" | "gruvbox" | "solarized";
-  primaryColor: string;
-  accentColor: string;
-  colorB1: string;
-  colorB2: string;
-  colorB3: string;
-  colorT1: string;
-  colorT2: string;
-}
+export type { CardOptions };
 
 export interface ActivityDisplay {
   height: number;


### PR DESCRIPTION
This adds nine named color presets as valid theme= values: Catppuccin Mocha, Catppuccin Latte, Catppuccin Frappé, Dracula, Nord, Tokyo Night, GitHub Dark, Gruvbox, and Solarized. Each preset is defined as a ColorTheme in src/helpers/themes.ts and resolved in the existing color-selection block in card.ts, so zero new render code was needed. The Zod enum in src/api/index.ts and the CardOptions union type in src/types.ts were extended to accept the new names, and all nine presets are surfaced in the playground theme picker in public/index.ejs.