### PR TITLE
feat: event-driven LRU response cache (closes #17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "src/server.ts",
   "packageManager": "pnpm@10.9.0",
   "dependencies": {
-    "apicache": "^1.6.3",
     "discord.js": "^14.25.1",
     "dotenv": "^16.6.1",
     "express": "^5.2.1",
@@ -16,7 +15,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "@types/apicache": "^1.6.8",
     "@types/express": "^4.17.25",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.19.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,9 +34,6 @@ importers:
 
   .:
     dependencies:
-      apicache:
-        specifier: ^1.6.3
-        version: 1.6.3
       discord.js:
         specifier: ^14.25.1
         version: 14.25.1
@@ -62,9 +59,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
-      '@types/apicache':
-        specifier: ^1.6.8
-        version: 1.6.8
       '@types/express':
         specifier: ^4.17.25
         version: 4.17.25
@@ -1485,9 +1479,6 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@types/apicache@1.6.8':
-    resolution: {integrity: sha512-PDBHDA9p/YEYRLL2KN2kr2UXRAWvZq/WM+GBN94MwPQRZORUnoazd1A1plZXWDOvCvGTgcKriRIIECnRpHhC/g==}
-
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1576,9 +1567,6 @@ packages:
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
-
-  '@types/redis@2.8.32':
-    resolution: {integrity: sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==}
 
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
@@ -1763,10 +1751,6 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  apicache@1.6.3:
-    resolution: {integrity: sha512-jS3VfUFpQ9BesFQZcdd1vVYg3ZsO2kGPmTJHqycIYPAQs54r74CRiyj8DuzJpwzLwIfCBYzh4dy9Jt8xYbo27w==}
-    engines: {node: '>=8'}
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -5663,11 +5647,6 @@ snapshots:
   '@tsconfig/node16@1.0.4':
     optional: true
 
-  '@types/apicache@1.6.8':
-    dependencies:
-      '@types/express': 4.17.25
-      '@types/redis': 2.8.32
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.5
@@ -5776,10 +5755,6 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
-
-  '@types/redis@2.8.32':
-    dependencies:
-      '@types/node': 22.19.3
 
   '@types/send@0.17.6':
     dependencies:
@@ -6010,8 +5985,6 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 4.0.4
-
-  apicache@1.6.3: {}
 
   arg@4.1.3:
     optional: true

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,30 @@ import { ParamsSchema } from "../schema";
 import type { CardOptions } from "../schema";
 import { discordMemberToLanyard } from "../helpers/lanyard";
 
+const lookupGuildMemberByUsername = (
+  client: Awaited<typeof readyClient>,
+  rawUsername: string
+) => {
+  const guildID = process.env.DISCORD_GUILD_ID as string;
+  const guild = client.guilds.cache.get(guildID);
+  if (!guild) return null;
+  const searchTerm = rawUsername.replace(/^@/, "").toLowerCase();
+  return (
+    guild.members.cache.find(
+      (m) =>
+        m.user.username.toLowerCase() === searchTerm ||
+        m.user.displayName.toLowerCase() === searchTerm ||
+        m.nickname?.toLowerCase() === searchTerm
+    ) || null
+  );
+};
+
+export const resolveUsernameToId = async (username: string): Promise<string | null> => {
+  if (!username || username.length < 2) return null;
+  const client = await readyClient;
+  return lookupGuildMemberByUsername(client, username)?.id ?? null;
+};
+
 export const discordSelf: RequestHandler = async (req, res, next) => {
   const client = await readyClient;
   res.status(200).send(`Discord logged in as ${client.user.username}`);
@@ -130,21 +154,12 @@ export const discordUsernameToID: RequestHandler = async (req, res, next) => {
 
   try {
     const guildID = process.env.DISCORD_GUILD_ID as string;
-    const guild = client.guilds.cache.get(guildID);
-
-    if (!guild) {
+    if (!client.guilds.cache.get(guildID)) {
       res.status(500).json({ error: "Guild not found" });
       return;
     }
 
-    // Search by username or display name (case-insensitive)
-    // Remove @ if present
-    const searchTerm = username.replace(/^@/, '').toLowerCase();
-    const member = guild.members.cache.find(m =>
-      m.user.username.toLowerCase() === searchTerm ||
-      m.user.displayName.toLowerCase() === searchTerm ||
-      m.nickname?.toLowerCase() === searchTerm
-    );
+    const member = lookupGuildMemberByUsername(client, username);
 
     if (!member) {
       res.status(404).json({ error: "User not found in server" });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,19 @@
 import express from "express";
-import apicache from "apicache";
 import { promises as fs } from "fs";
 import path from "path";
-import { discordSelf, discordUser, discordIDToUsername, discordUsernameToID, pseudoLanyardImplementation } from "./api";
+import {
+  discordSelf,
+  discordUser,
+  discordIDToUsername,
+  discordUsernameToID,
+  pseudoLanyardImplementation,
+  resolveUsernameToId,
+} from "./api";
 import 'dotenv/config';
 import readyClient from "./bot";
+import { withResponseCache } from "./helpers/responseCache";
 
 const app = express();
-const cache = apicache.middleware;
 
 let fallbackUserId = "879917497959219250";
 let fallbackUserName = "tsunibot";
@@ -55,14 +61,17 @@ app.get("/", async (_req, res) => {
 
 app.use(express.static("./public"));
 
+const idFromParams = (req: express.Request) => req.params.id ?? null;
+
 app.get("/api/ping", discordSelf);
-app.get("/api/user/:id", cache(process.env.NODE_ENV === 'development' ? '1 second' : '30 seconds'), discordUser);
-app.get("/api/username/:id", cache(process.env.NODE_ENV === 'development' ? '1 second' : '30 seconds'), discordIDToUsername);
+app.get("/api/user/:id", withResponseCache(discordUser, { userIdFor: idFromParams }));
+app.get("/api/username/:id", withResponseCache(discordIDToUsername, { userIdFor: idFromParams }));
 app.get(
   "/api/lookup/:username",
-  cache(process.env.NODE_ENV === "development" ? "1 second" : "30 seconds"),
-  discordUsernameToID
+  withResponseCache(discordUsernameToID, {
+    userIdFor: (req) => resolveUsernameToId(req.params.username),
+  })
 );
-app.get("/api/lanyard/:id", cache(process.env.NODE_ENV === 'development' ? '1 second' : '30 seconds'), pseudoLanyardImplementation);
+app.get("/api/lanyard/:id", withResponseCache(pseudoLanyardImplementation, { userIdFor: idFromParams }));
 
 export default app;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,9 +1,10 @@
 import { Client, Events, GatewayIntentBits } from 'discord.js';
 import 'dotenv/config';
+import { responseCache } from './helpers/responseCache';
 
 const client = new Client({ intents: [
   GatewayIntentBits.Guilds,
-  GatewayIntentBits.GuildMembers, 
+  GatewayIntentBits.GuildMembers,
   GatewayIntentBits.GuildPresences,
 ] });
 
@@ -16,6 +17,22 @@ readyClient = new Promise((resolve) => {
     console.log(`Discord logged in as ${readyClient.user.tag}`);
     resolve(readyClient);
   });
+});
+
+const watchedGuildId = process.env.DISCORD_GUILD_ID;
+
+client.on(Events.PresenceUpdate, (_oldPresence, newPresence) => {
+  if (watchedGuildId && newPresence.guild?.id !== watchedGuildId) return;
+  if (newPresence.userId) responseCache.invalidateUser(newPresence.userId);
+});
+
+client.on(Events.GuildMemberUpdate, (_oldMember, newMember) => {
+  if (watchedGuildId && newMember.guild.id !== watchedGuildId) return;
+  responseCache.invalidateUser(newMember.id);
+});
+
+client.on(Events.UserUpdate, (_oldUser, newUser) => {
+  responseCache.invalidateUser(newUser.id);
 });
 
 export default readyClient;

--- a/src/helpers/responseCache.ts
+++ b/src/helpers/responseCache.ts
@@ -1,0 +1,146 @@
+import LRUCacheWithDelete from "mnemonist/lru-cache-with-delete";
+import type { Request, RequestHandler } from "express";
+
+export interface CachedResponse {
+  body: string;
+  contentType: string;
+  status: number;
+  createdAt: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 5000;
+const DEFAULT_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+const KEY_SEP = "::";
+
+const parseEnvInt = (raw: string | undefined, fallback: number) => {
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+const MAX_ENTRIES = parseEnvInt(process.env.RESPONSE_CACHE_MAX, DEFAULT_MAX_ENTRIES);
+const MAX_AGE_MS = parseEnvInt(process.env.RESPONSE_CACHE_MAX_AGE_MS, DEFAULT_MAX_AGE_MS);
+
+const entries = new LRUCacheWithDelete<string, CachedResponse>(MAX_ENTRIES);
+const byUser = new Map<string, Set<string>>();
+
+const compositeKey = (userId: string, variantKey: string) => `${userId}${KEY_SEP}${variantKey}`;
+const userIdFromKey = (key: string) => key.slice(0, key.indexOf(KEY_SEP));
+
+const detachFromUser = (key: string) => {
+  const uid = userIdFromKey(key);
+  const set = byUser.get(uid);
+  if (!set) return;
+  set.delete(key);
+  if (set.size === 0) byUser.delete(uid);
+};
+
+export const responseCache = {
+  get(userId: string, variantKey: string): CachedResponse | undefined {
+    const key = compositeKey(userId, variantKey);
+    const hit = entries.get(key);
+    if (!hit) return undefined;
+    if (Date.now() - hit.createdAt > MAX_AGE_MS) {
+      entries.delete(key);
+      detachFromUser(key);
+      return undefined;
+    }
+    return hit;
+  },
+
+  set(userId: string, variantKey: string, entry: CachedResponse): void {
+    const key = compositeKey(userId, variantKey);
+    const result = entries.setpop(key, entry);
+    // result === null  => fresh insert with room to spare
+    // result.evicted === false => key already existed; reverse index already tracks it
+    // result.evicted === true  => a different LRU entry was popped to make room
+    if (result && result.evicted) {
+      detachFromUser(result.key);
+    }
+    let set = byUser.get(userId);
+    if (!set) {
+      set = new Set();
+      byUser.set(userId, set);
+    }
+    set.add(key);
+  },
+
+  invalidateUser(userId: string): number {
+    const set = byUser.get(userId);
+    if (!set) return 0;
+    let removed = 0;
+    for (const key of set) {
+      if (entries.delete(key)) removed++;
+    }
+    byUser.delete(userId);
+    return removed;
+  },
+
+  // Test/debug helpers
+  _stats() {
+    return { entries: entries.size, users: byUser.size, capacity: MAX_ENTRIES };
+  },
+  _clear() {
+    entries.clear();
+    byUser.clear();
+  },
+};
+
+const canonicalVariantKey = (req: Request): string => {
+  const keys = Object.keys(req.query).sort();
+  const parts: string[] = [];
+  for (const k of keys) {
+    const v = req.query[k];
+    parts.push(`${k}=${Array.isArray(v) ? v.join(",") : String(v)}`);
+  }
+  return `${req.path}?${parts.join("&")}`;
+};
+
+export interface CacheWrapOptions {
+  userIdFor: (req: Request) => string | null | Promise<string | null>;
+}
+
+export const withResponseCache = (
+  handler: RequestHandler,
+  options: CacheWrapOptions
+): RequestHandler => {
+  return async (req, res, next) => {
+    let userId: string | null;
+    try {
+      userId = await options.userIdFor(req);
+    } catch {
+      userId = null;
+    }
+    if (!userId) {
+      return handler(req, res, next);
+    }
+    const variantKey = canonicalVariantKey(req);
+    const hit = responseCache.get(userId, variantKey);
+    if (hit) {
+      res.set("X-Cache", "HIT");
+      res.set("Content-Type", hit.contentType);
+      res.status(hit.status).send(hit.body);
+      return;
+    }
+    res.set("X-Cache", "MISS");
+    const originalSend = res.send.bind(res);
+    res.send = function (body: unknown) {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        const serialized =
+          typeof body === "string"
+            ? body
+            : Buffer.isBuffer(body)
+              ? body.toString("utf8")
+              : JSON.stringify(body);
+        responseCache.set(userId!, variantKey, {
+          body: serialized,
+          contentType: (res.get("Content-Type") as string) || "text/plain",
+          status: res.statusCode,
+          createdAt: Date.now(),
+        });
+      }
+      return originalSend(body);
+    };
+    return handler(req, res, next);
+  };
+};


### PR DESCRIPTION
## Summary

Closes #17. Replaces the fixed-TTL `apicache` middleware with an LRU response cache invalidated by Discord gateway events. Cached SVGs now live for as long as the user's Discord state actually stays unchanged, instead of being thrown away every 30 seconds — and the cache stays bounded under arbitrary traffic.

## Changes

- **New module** `src/helpers/responseCache.ts`
  - `LRUCacheWithDelete<string, CachedResponse>` (from existing `mnemonist` dep) sized by `RESPONSE_CACHE_MAX` env var (default 5000).
  - Composite key `${userId}::${path}?{sorted-query}` so different render variants (theme, width, layout, colors, etc.) get isolated entries automatically and don't have to be enumerated.
  - `byUser: Map<string, Set<key>>` reverse index lets `invalidateUser(userId)` flush every cached variant for that user in O(k). The index is kept consistent with LRU evictions (`setpop` reports what got popped → we detach it from the index) so it can't leak as the LRU cycles.
  - `MAX_AGE_MS` safety floor (default 6 h) re-checked inside `get`, in case a gateway event is ever missed (reconnect, sharding, etc.).
  - `withResponseCache(handler, { userIdFor })` Express helper: derives `userId`, checks the cache, sets `X-Cache: HIT|MISS`, and on miss captures `res.send` output (status, body, content-type) into the cache for next time.

- **Gateway invalidation** in `src/bot.ts`: `PresenceUpdate`, `GuildMemberUpdate`, and `UserUpdate` listeners each call `responseCache.invalidateUser(...)`. Guild-scoped events are filtered to `DISCORD_GUILD_ID` so we don't churn the cache if the bot ever joins additional guilds.

- **Wrapping in `src/app.ts`**: `apicache` is removed; the four cacheable routes (`/api/user/:id`, `/api/username/:id`, `/api/lookup/:username`, `/api/lanyard/:id`) are wrapped with `withResponseCache`. For `/api/lookup/:username` we resolve the username to a user ID up front (via the existing in-guild-members-cache lookup, factored into `lookupGuildMemberByUsername`) so that invalidation events (which carry user IDs) hit it too.

- **Dependency cleanup**: dropped `apicache` and `@types/apicache` from `package.json`.

## Knobs

| env var | default | meaning |
| --- | --- | --- |
| `RESPONSE_CACHE_MAX` | 5000 | max entries before LRU eviction kicks in |
| `RESPONSE_CACHE_MAX_AGE_MS` | 21600000 (6 h) | safety TTL floor |

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] Standalone verification of the cache module: basic get/set, variant isolation, per-user invalidation, LRU eviction at capacity, reverse-index hygiene under overflow (no orphans), update semantics. 16/16 assertions green.
- [x] Standalone Express integration through `supertest`: first request `X-Cache: MISS`, repeat `HIT`, distinct query variant `MISS`, `responseCache.invalidateUser(...)` flushes the entry. 12/12 assertions green.
- [ ] Manual smoke on `pnpm dev` with `DISCORD_TOKEN` set: `curl -i` the same URL twice → first MISS, second HIT; change the watched user's Discord status → next request MISS while another user's entry stays HIT.
- [ ] (existing) `pnpm test` is gated on a real `DISCORD_TOKEN` because `tests/app.test.ts` boots `app`, which logs the bot in; this PR doesn't change that.

## Notes

Pre-existing `pnpm lint` failure on this branch (`ESLint: TypeError: Cannot set properties of undefined (setting 'defaultMeta')`) is unrelated — same failure on `main`.

https://claude.ai/code/session_01AARFqszZcVNt8V1QtkFQV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AARFqszZcVNt8V1QtkFQV7)_